### PR TITLE
use main instead of latest docker tag

### DIFF
--- a/config/base/deployment.yaml
+++ b/config/base/deployment.yaml
@@ -17,7 +17,4 @@ spec:
     spec:
       containers:
       - name: receipt-verifier
-        image: coilhq/receipt-verifier
-        env:
-        - name: REDIS_URI
-          value: mock
+        image: coilhq/receipt-verifier:main


### PR DESCRIPTION
Docker Github Action only tags master branch as latest
https://github.com/docker/build-push-action#tag_with_ref

don't use mock redis in default config