### PR TITLE
Add missing npm build step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For [Web Monetization](https://github.com/interledger/rfcs/blob/master/0028-web-
 
 ```
 npm install
+npm run-script build
 sudo docker run -p 6379:6379 -d redis
 SPSP_ENDPOINT=https://receiver-endpoint.com npm start
 ```


### PR DESCRIPTION
When following the "Run" instructions in the README exactly, I got the error below. This small documentation update adds the missing step I needed to run the application to the README.

(Note: I'm not a Node developer, so this might not be the best solution -- it just worked for me.)

Error log:

```
$ npm start
> @coil/receipt-verifier@1.0.5 start /home/user/receipt-verifier
> node dist/index.js

internal/modules/cjs/loader.js:969
  throw err;
  ^

Error: Cannot find module '/home/user/receipt-verifier/dist/index.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:966:15)
    at Function.Module._load (internal/modules/cjs/loader.js:842:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
    at internal/main/run_main_module.js:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @coil/receipt-verifier@1.0.5 start: `node dist/index.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @coil/receipt-verifier@1.0.5 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```